### PR TITLE
Improve logging for index classes

### DIFF
--- a/class/ndmi.class.php
+++ b/class/ndmi.class.php
@@ -1272,17 +1272,20 @@ class NDMI extends CommonObject
 				'MAXCC' => '100'
 			);
 
-			// Configura a URL com os parâmetros
-			// echo $url . '?' . http_build_query($params);
-			curl_setopt($ch, CURLOPT_URL, $url . '?' . http_build_query($params));
+                        // Configura a URL com os parâmetros
+                        $requestUrl = $url . '?' . http_build_query($params);
+                        // echo $requestUrl;
+                        curl_setopt($ch, CURLOPT_URL, $requestUrl);
 
 			// Executa a sessão cURL
 			$response = curl_exec($ch);
 
-			// Verifica erros
-			if (curl_errno($ch)) {
-				echo 'Erro no cURL: ' . curl_error($ch);
-			}
+                        // Verifica erros
+                        if (curl_errno($ch)) {
+                                $err = curl_error($ch);
+                                dol_syslog(__METHOD__.' cURL error on '.$requestUrl.' - '.$err, LOG_ERR);
+                                setEventMessages('Erro ao consultar dados remotos', null, 'errors');
+                        }
 
 			// Fecha a sessão cURL
 			curl_close($ch);
@@ -1297,13 +1300,14 @@ class NDMI extends CommonObject
 
 
 			// Salva a resposta em um arquivo
-			if (!file_put_contents($file_path, $response)) {
-				// echo "Erro ao salvar o arquivo.";
-			} else {
-				if(filesize($file_path)<1000 && $cont == 0){
-					echo "sem dados para esse periodo!";
-					$cont++;
-				}
+                        if (!file_put_contents($file_path, $response)) {
+                                dol_syslog(__METHOD__.' failed to write '.$file_path, LOG_ERR);
+                        } else {
+                                if (filesize($file_path) < 1000 && $cont == 0) {
+                                        dol_syslog(__METHOD__.' no data returned for '.$requestUrl, LOG_WARNING);
+                                        setEventMessages('Sem dados para esse periodo!', null, 'warnings');
+                                        $cont++;
+                                }
 			}
 
 			$ndmi = new NDMI($this->db);

--- a/class/ndvi.class.php
+++ b/class/ndvi.class.php
@@ -1271,17 +1271,20 @@ class NDVI extends CommonObject
 				'MAXCC' => '100'
 			);
 	
-			// Configura a URL com os parâmetros
-			// echo $url . '?' . http_build_query($params);
-			curl_setopt($ch, CURLOPT_URL, $url . '?' . http_build_query($params));
+                        // Configura a URL com os parâmetros
+                        $requestUrl = $url . '?' . http_build_query($params);
+                        // echo $requestUrl;
+                        curl_setopt($ch, CURLOPT_URL, $requestUrl);
 	
 			// Executa a sessão cURL
 			$response = curl_exec($ch);
 	
-			// Verifica erros
-			if (curl_errno($ch)) {
-				echo 'Erro no cURL: ' . curl_error($ch);
-			}
+                        // Verifica erros
+                        if (curl_errno($ch)) {
+                                $err = curl_error($ch);
+                                dol_syslog(__METHOD__.' cURL error on '.$requestUrl.' - '.$err, LOG_ERR);
+                                setEventMessages('Erro ao consultar dados remotos', null, 'errors');
+                        }
 	
 			// Fecha a sessão cURL
 			curl_close($ch);
@@ -1296,13 +1299,14 @@ class NDVI extends CommonObject
 
 			
 			// Salva a resposta em um arquivo
-			if (!file_put_contents($file_path, $response)) {
-				// echo "Erro ao salvar o arquivo.";
-			} else {
-				if(filesize($file_path)<1000 && $cont == 0){
-					echo "sem dados para esse periodo!";
-					$cont++;
-				}
+                        if (!file_put_contents($file_path, $response)) {
+                                dol_syslog(__METHOD__.' failed to write '.$file_path, LOG_ERR);
+                        } else {
+                                if (filesize($file_path) < 1000 && $cont == 0) {
+                                        dol_syslog(__METHOD__.' no data returned for '.$requestUrl, LOG_WARNING);
+                                        setEventMessages('Sem dados para esse periodo!', null, 'warnings');
+                                        $cont++;
+                                }
 			}
 			
 			$ndvi = new NDVI($this->db);

--- a/class/ndwi.class.php
+++ b/class/ndwi.class.php
@@ -1280,17 +1280,20 @@ class NDWI extends CommonObject
 				'MAXCC' => '100'
 			);
 	
-			// Configura a URL com os parâmetros
-			// echo $url . '?' . http_build_query($params);
-			curl_setopt($ch, CURLOPT_URL, $url . '?' . http_build_query($params));
+                        // Configura a URL com os parâmetros
+                        $requestUrl = $url . '?' . http_build_query($params);
+                        // echo $requestUrl;
+                        curl_setopt($ch, CURLOPT_URL, $requestUrl);
 	
 			// Executa a sessão cURL
 			$response = curl_exec($ch);
 	
-			// Verifica erros
-			if (curl_errno($ch)) {
-				echo 'Erro no cURL: ' . curl_error($ch);
-			}
+                        // Verifica erros
+                        if (curl_errno($ch)) {
+                                $err = curl_error($ch);
+                                dol_syslog(__METHOD__.' cURL error on '.$requestUrl.' - '.$err, LOG_ERR);
+                                setEventMessages('Erro ao consultar dados remotos', null, 'errors');
+                        }
 	
 			// Fecha a sessão cURL
 			curl_close($ch);
@@ -1305,13 +1308,14 @@ class NDWI extends CommonObject
 
 			
 			// Salva a resposta em um arquivo
-			if (!file_put_contents($file_path, $response)) {
-				// echo "Erro ao salvar o arquivo.";
-			} else {
-				if(filesize($file_path)<1000 && $cont == 0){
-					echo "sem dados para esse periodo!";
-					$cont++;
-				}
+                        if (!file_put_contents($file_path, $response)) {
+                                dol_syslog(__METHOD__.' failed to write '.$file_path, LOG_ERR);
+                        } else {
+                                if (filesize($file_path) < 1000 && $cont == 0) {
+                                        dol_syslog(__METHOD__.' no data returned for '.$requestUrl, LOG_WARNING);
+                                        setEventMessages('Sem dados para esse periodo!', null, 'warnings');
+                                        $cont++;
+                                }
 			}
 			
 			$ndwi = new NDWI($this->db);

--- a/class/swir.class.php
+++ b/class/swir.class.php
@@ -1279,17 +1279,20 @@ class SWIR extends CommonObject
 				'MAXCC' => '100'
 			);
 	
-			// Configura a URL com os parâmetros
-			// echo $url . '?' . http_build_query($params);
-			curl_setopt($ch, CURLOPT_URL, $url . '?' . http_build_query($params));
+                        // Configura a URL com os parâmetros
+                        $requestUrl = $url . '?' . http_build_query($params);
+                        // echo $requestUrl;
+                        curl_setopt($ch, CURLOPT_URL, $requestUrl);
 	
 			// Executa a sessão cURL
 			$response = curl_exec($ch);
 	
-			// Verifica erros
-			if (curl_errno($ch)) {
-				echo 'Erro no cURL: ' . curl_error($ch);
-			}
+                        // Verifica erros
+                        if (curl_errno($ch)) {
+                                $err = curl_error($ch);
+                                dol_syslog(__METHOD__.' cURL error on '.$requestUrl.' - '.$err, LOG_ERR);
+                                setEventMessages('Erro ao consultar dados remotos', null, 'errors');
+                        }
 	
 			// Fecha a sessão cURL
 			curl_close($ch);
@@ -1304,13 +1307,14 @@ class SWIR extends CommonObject
 
 			
 			// Salva a resposta em um arquivo
-			if (!file_put_contents($file_path, $response)) {
-				// echo "Erro ao salvar o arquivo.";
-			} else {
-				if(filesize($file_path)<1000 && $cont == 0){
-					echo "sem dados para esse periodo!";
-					$cont++;
-				}
+                        if (!file_put_contents($file_path, $response)) {
+                                dol_syslog(__METHOD__.' failed to write '.$file_path, LOG_ERR);
+                        } else {
+                                if (filesize($file_path) < 1000 && $cont == 0) {
+                                        dol_syslog(__METHOD__.' no data returned for '.$requestUrl, LOG_WARNING);
+                                        setEventMessages('Sem dados para esse periodo!', null, 'warnings');
+                                        $cont++;
+                                }
 			}
 			
 			$swir = new SWIR($this->db);


### PR DESCRIPTION
## Summary
- replace `echo` statements with `dol_syslog` and `setEventMessages`
- log request details when calling Sentinel Hub
- warn when files have no data

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b8eb51c88330b5a0e4f1344295e4