### PR TITLE
Improve talhão map tools with circle-to-polygon support

### DIFF
--- a/css/safra.css.php
+++ b/css/safra.css.php
@@ -152,7 +152,7 @@ div.mainmenu.safra {
 
 	#mapList {
 		z-index: 0;
-		width: 95%;
+		width: 100%;
 		height: 300px;
 	}
 	#mapCRUD {
@@ -180,25 +180,24 @@ div.mainmenu.safra {
 	.container {
 		display: flex;
 		flex-wrap: nowrap;
-		flex-direction: row;
+		flex-direction: column;
 		justify-content: start;
 		align-items: auto;
 		align-content: start;
 	}
 	.item {
 		flex: 0 0 auto;
+                width: 100%;
 		margin: 10px 0 0 10px;
 		/* max-width: 45%; */
 	}
 	#mapList {
 		z-index: 0;
-		width: 29rem;
-		height: 40rem;
+		width: 100%;
+		height: 15rem;
 	}
 	#mapCRUD {
 		z-index: 0;
-		width: 40rem;
-		max-width: 50%;
 		height: 40rem;
 	}
 	#mapShow {

--- a/js/talhao_create.js.php
+++ b/js/talhao_create.js.php
@@ -4,162 +4,324 @@
 <script src="./js/leaflet.js"></script>
 <script src="./js/leaflet.draw.js"></script>
 <script src="./js/wellknown.js"></script>
+<script src="./js/turf.js"></script>
 
 
 
 <script>
-    
-var map = L.map('mapCRUD').setView([-17.047558, -46.824176], 13);
+const MAP_INITIAL_CENTER = [-17.047558, -46.824176];
+const MAP_INITIAL_ZOOM = 13;
+const CIRCLE_STEPS = 128;
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Map data &copy; OpenStreetMap contributors'
-}).addTo(map);
+var map = L.map('mapCRUD').setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
+
+var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data &copy; OpenStreetMap contributors'
+});
+
+var googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
+        maxZoom: 20,
+        subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
+});
+
+osmLayer.addTo(map);
+
+var baseLayers = {
+        'OpenStreetMap': osmLayer,
+        'Satélite (Google)': googleHybrid
+};
+
+L.control.layers(baseLayers, null, {position: 'topright'}).addTo(map);
+L.control.scale({position: 'bottomright', metric: true, imperial: false}).addTo(map);
 
 var drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 
-googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
-    maxZoom: 20,
-    subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
-});
-googleHybrid.addTo(map);
+customizeDrawTexts();
 
 var drawControl = new L.Control.Draw({
-    edit: {
-        featureGroup: drawnItems
-    },
-    draw: {
-        polygon: {
-            allowIntersection: false,
-            showArea: true
+        edit: {
+                featureGroup: drawnItems,
+                remove: true
         },
-        polyline: false,
-        rectangle: {
-            showArea: true
-        },
-        circle: false,
-        marker: false
-    }
+        draw: {
+                polygon: {
+                        allowIntersection: false,
+                        showArea: true,
+                        shapeOptions: defaultShapeOptions()
+                },
+                rectangle: false,
+                polyline: false,
+                marker: false,
+                circlemarker: false,
+                circle: {
+                        showRadius: true,
+                        shapeOptions: defaultShapeOptions()
+                }
+        }
 });
 map.addControl(drawControl);
 
-// Variável para armazenar o polígono desenhado
-var drawnPolygon;
+var drawnPolygon = null;
 
 map.on(L.Draw.Event.CREATED, function (event) {
-    var layer = event.layer;
+        var layer = event.layer;
 
-    // Verifica se um polígono já foi desenhado
-    if (drawnPolygon) {
-        drawnItems.removeLayer(drawnPolygon);
-    }
+        if (event.layerType === 'circle') {
+                layer = convertCircleToPolygon(layer) || layer;
+        }
 
-    // Adiciona o novo polígono e atualiza a variável
-    drawnItems.addLayer(layer);
-    drawnPolygon = layer;
-
-    updateInputs(layer);
+        applySingleLayer(layer);
+        focusOnDrawing();
 });
 
 map.on('draw:edited', function (e) {
-    var layers = e.layers;
-    layers.eachLayer(function (layer) {
-        drawnItems.addLayer(layer);
-        updateInputs(layer);
-        // fetchNDVIData(layer);
-    });
+        e.layers.eachLayer(function (layer) {
+                drawnPolygon = layer;
+                if (layer.setStyle) {
+                        layer.setStyle(defaultShapeOptions());
+                }
+                createAreaTooltip(layer);
+                updateInputs(layer);
+        });
+        focusOnDrawing();
 });
 
-function updateInputs(layer) {
-    var bounds = layer.getBounds();
-    var bbox = bounds.toBBoxString();
-    var geojson = layer.toGeoJSON(); 
-    var wkt = wellknown.stringify(geojson);
-    var encondedWKT = encodeURIComponent(wkt);
-    var input_geojson = document.getElementById("geo_json")
-    input_geojson.value = JSON.stringify(geojson);
-    var input_wkt = document.getElementById("wkt")
-    input_wkt.value = encondedWKT;
-    var input_bbox = document.getElementById("bbox")
-    input_bbox.value = bbox;
+map.on('draw:deleted', function () {
+        resetInputs();
+        drawnPolygon = null;
+        focusOnDrawing();
+});
 
-    createAreaTooltip(layer);
-    var area = L.GeometryUtil.geodesicArea(layer.getLatLngs()[0]); // Get polygon area
-    var areaHa = area / 10000; // Convert area to hectares
-    var input_area = document.getElementById("area")
-    input_area.value = areaHa;
+var fitButton = document.getElementById('fit-drawing');
+if (fitButton) {
+        fitButton.addEventListener('click', function () {
+                focusOnDrawing();
+        });
 }
 
+var clearButton = document.getElementById('clear-drawing');
+if (clearButton) {
+        clearButton.addEventListener('click', function () {
+                handleClearDrawing();
+        });
+}
 
+window.addEventListener('resize', function () {
+        map.invalidateSize();
+});
 
-function fetchNDVIData(layer) {
-    var wkt = wellknown.stringify(layer.toGeoJSON());
-    var encodedWKT = encodeURIComponent(wkt);
-    var url = `https://services.sentinel-hub.com/ogc/wms/3f380032-35a2-468e-83b2-0363da66b000?service=WMS&request=GetMap&layers=NDVI&styles=&format=application/json&transparent=true&RESX=10m&RESY=10m&srs=CRS:84&geometry=${encodedWKT}/`;
-    console.log(url);
+map.whenReady(function () {
+        setTimeout(function () {
+                map.invalidateSize();
+        }, 150);
+});
 
-    // Fetch NDVI data in GeoJSON
-    fetch(url)
-        .then(response => response.json())
-        .then(data => {
-            let counter = 0;
-            var geoJsonLayer = L.geoJSON(data, {
-                onEachFeature: function (feature, layer) {
-                    layer.setStyle({
-                        color: `#${feature.properties.COLOR_HEX}`,
-                        stroke: true,
-                        weight: 1,
-                        fill: true,
-                        fillOpacity: 1,
-                        fillColor: `#${feature.properties.COLOR_HEX}`
-                    });
-                    counter++;
+function customizeDrawTexts() {
+        if (!L.drawLocal || !L.drawLocal.draw) {
+                return;
+        }
+
+        var buttons = L.drawLocal.draw.toolbar.buttons || {};
+        buttons.polygon = 'Desenhar polígono';
+        buttons.circle = 'Desenhar pivô (círculo)';
+        buttons.rectangle = 'Desenhar retângulo';
+        L.drawLocal.draw.toolbar.buttons = buttons;
+
+        if (L.drawLocal.draw.handlers && L.drawLocal.draw.handlers.circle && L.drawLocal.draw.handlers.circle.tooltip) {
+                L.drawLocal.draw.handlers.circle.tooltip.start = 'Clique e arraste para desenhar o pivô circular.';
+        }
+        if (L.drawLocal.draw.handlers && L.drawLocal.draw.handlers.polygon && L.drawLocal.draw.handlers.polygon.tooltip) {
+                L.drawLocal.draw.handlers.polygon.tooltip.start = 'Clique para adicionar vértices ao polígono.';
+        }
+}
+
+function defaultShapeOptions() {
+        return {
+                color: '#0b6fa4',
+                weight: 2,
+                fillColor: '#3ba1d7',
+                fillOpacity: 0.25
+        };
+}
+
+function applySingleLayer(layer) {
+        if (!layer) {
+                return;
+        }
+
+        drawnItems.clearLayers();
+        if (layer.setStyle) {
+                layer.setStyle(defaultShapeOptions());
+        }
+        drawnItems.addLayer(layer);
+        drawnPolygon = layer;
+        createAreaTooltip(layer);
+        updateInputs(layer);
+        return layer;
+}
+
+function handleClearDrawing() {
+        drawnItems.clearLayers();
+        resetInputs();
+        drawnPolygon = null;
+        map.setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
+}
+
+function focusOnDrawing() {
+        if (drawnPolygon) {
+                map.fitBounds(drawnPolygon.getBounds(), {padding: [40, 40]});
+        } else {
+                map.setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
+        }
+}
+
+function convertCircleToPolygon(circleLayer) {
+        var center = circleLayer.getLatLng();
+        var polygonGeo = turf.circle([center.lng, center.lat], circleLayer.getRadius() / 1000, {
+                steps: CIRCLE_STEPS,
+                units: 'kilometers'
+        });
+
+        var polygonLayers = L.geoJSON(polygonGeo).getLayers();
+        if (polygonLayers.length) {
+                var polygonLayer = polygonLayers[0];
+                if (circleLayer.options && polygonLayer.setStyle) {
+                        polygonLayer.setStyle(circleLayer.options);
+                } else if (polygonLayer.setStyle) {
+                        polygonLayer.setStyle(defaultShapeOptions());
                 }
-            }).addTo(map);
-            map.fitBounds(geoJsonLayer.getBounds());
-        })
-        .catch(error => console.error('Error fetching NDVI data:', error));
+                return polygonLayer;
+        }
+
+        return null;
 }
 
+function getPrimaryLatLngs(layer) {
+        if (!layer || typeof layer.getLatLngs !== 'function') {
+                return [];
+        }
+
+        return extractFirstRing(layer.getLatLngs());
+}
+
+function extractFirstRing(latLngs) {
+        if (!Array.isArray(latLngs)) {
+                return [];
+        }
+        if (!latLngs.length) {
+                return [];
+        }
+        if (Array.isArray(latLngs[0])) {
+                return extractFirstRing(latLngs[0]);
+        }
+        return latLngs;
+}
+
+function updateInputs(layer) {
+        if (!layer) {
+                return;
+        }
+
+        var bounds = layer.getBounds();
+        if (bounds && typeof bounds.isValid === 'function' && !bounds.isValid()) {
+                return;
+        }
+
+        var bbox = bounds.toBBoxString();
+        var geojson = layer.toGeoJSON();
+        var wkt = wellknown.stringify(geojson);
+        var encodedWKT = encodeURIComponent(wkt);
+
+        var inputGeoJson = document.getElementById('geo_json');
+        if (inputGeoJson) {
+                inputGeoJson.value = JSON.stringify(geojson);
+        }
+
+        var inputWkt = document.getElementById('wkt');
+        if (inputWkt) {
+                inputWkt.value = encodedWKT;
+        }
+
+        var inputBbox = document.getElementById('bbox');
+        if (inputBbox) {
+                inputBbox.value = bbox;
+        }
+
+        var latLngs = getPrimaryLatLngs(layer);
+        if (latLngs.length && L.GeometryUtil && L.GeometryUtil.geodesicArea) {
+                var area = L.GeometryUtil.geodesicArea(latLngs);
+                var inputArea = document.getElementById('area');
+                if (inputArea) {
+                        inputArea.value = area / 10000;
+                }
+        }
+
+        updateAreaTooltip(layer);
+}
+
+function resetInputs() {
+        ['geo_json', 'wkt', 'bbox', 'area'].forEach(function (fieldId) {
+                var input = document.getElementById(fieldId);
+                if (input) {
+                        input.value = '';
+                }
+        });
+}
 
 function createAreaTooltip(layer) {
-            if (layer.areaTooltip) {
+        if (!layer || typeof layer.getLatLngs !== 'function') {
+                return;
+        }
+
+        if (layer.areaTooltip) {
                 updateAreaTooltip(layer);
                 return;
-            }
+        }
 
-            layer.areaTooltip = L.tooltip({
+        layer.areaTooltip = L.tooltip({
                 permanent: true,
                 direction: 'center',
                 className: 'area-tooltip'
-            });
+        });
 
-            layer.on('remove', function(event) {
-                layer.areaTooltip.remove();
-            });
+        layer.on('remove', function () {
+                if (layer.areaTooltip) {
+                        layer.areaTooltip.remove();
+                }
+        });
 
-            layer.on('add', function(event) {
+        layer.on('add', function () {
+                updateAreaTooltip(layer);
+                if (layer.areaTooltip) {
+                        layer.areaTooltip.addTo(map);
+                }
+        });
+
+        if (map.hasLayer(layer) && layer.areaTooltip) {
                 updateAreaTooltip(layer);
                 layer.areaTooltip.addTo(map);
-            });
+        }
+}
 
-            if (map.hasLayer(layer)) {
-                updateAreaTooltip(layer);
-                layer.areaTooltip.addTo(map);
-            }
+function updateAreaTooltip(layer) {
+        if (!layer || !layer.areaTooltip) {
+                return;
         }
 
-        function updateAreaTooltip(layer) {
-            var area = L.GeometryUtil.geodesicArea(layer.getLatLngs()[0]);
-            var readableArea = L.GeometryUtil.readableArea(area, true);
-            var latlng = layer.getCenter();
+        var latLngs = getPrimaryLatLngs(layer);
+        if (!latLngs.length || !L.GeometryUtil || !L.GeometryUtil.geodesicArea) {
+                return;
+        }
 
-            layer.areaTooltip
+        var area = L.GeometryUtil.geodesicArea(latLngs);
+        var readableArea = L.GeometryUtil.readableArea(area, true);
+        var center = layer.getBounds().getCenter();
+
+        layer.areaTooltip
                 .setContent(readableArea)
-                .setLatLng(latlng);
-        }
-
-
+                .setLatLng(center);
+}
 </script>
 
 

--- a/js/talhao_create.js.php
+++ b/js/talhao_create.js.php
@@ -15,20 +15,26 @@ const CIRCLE_STEPS = 128;
 
 var map = L.map('mapCRUD').setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
 
+var satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+        maxZoom: 20
+});
+
 var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data &copy; OpenStreetMap contributors'
 });
 
-var googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
+var googleHybrid = L.tileLayer('https://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
         maxZoom: 20,
         subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
 });
 
-osmLayer.addTo(map);
+satelliteLayer.addTo(map);
 
 var baseLayers = {
-        'OpenStreetMap': osmLayer,
-        'Satélite (Google)': googleHybrid
+        'Imagem de satélite (Esri)': satelliteLayer,
+        'Satélite (Google)': googleHybrid,
+        'Mapa de ruas (OSM)': osmLayer
 };
 
 L.control.layers(baseLayers, null, {position: 'topright'}).addTo(map);

--- a/js/talhao_edit.js.php
+++ b/js/talhao_edit.js.php
@@ -17,20 +17,26 @@ const CIRCLE_STEPS = 128;
 
 var map = L.map('mapCRUD').setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
 
+var satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+        maxZoom: 20
+});
+
 var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data &copy; OpenStreetMap contributors'
 });
 
-var googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
+var googleHybrid = L.tileLayer('https://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
         maxZoom: 20,
         subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
 });
 
-osmLayer.addTo(map);
+satelliteLayer.addTo(map);
 
 var baseLayers = {
-        'OpenStreetMap': osmLayer,
-        'Satélite (Google)': googleHybrid
+        'Imagem de satélite (Esri)': satelliteLayer,
+        'Satélite (Google)': googleHybrid,
+        'Mapa de ruas (OSM)': osmLayer
 };
 
 L.control.layers(baseLayers, null, {position: 'topright'}).addTo(map);

--- a/js/talhao_edit.js.php
+++ b/js/talhao_edit.js.php
@@ -4,177 +4,374 @@
 <script src="./js/leaflet.js"></script>
 <script src="./js/leaflet.draw.js"></script>
 <script src="./js/wellknown.js"></script>
+<script src="./js/turf.js"></script>
 
 
 
 <script>
 <?php $sentinelHubId = getDolGlobalString('SAFRA_API_SENTINELHUB'); ?>
 const SENTINELHUB_ID = '<?php echo addslashes($sentinelHubId); ?>';
+const MAP_INITIAL_CENTER = [-17.047558, -46.824176];
+const MAP_INITIAL_ZOOM = 13;
+const CIRCLE_STEPS = 128;
 
-var map = L.map('mapCRUD').setView([-17.047558, -46.824176], 13);
+var map = L.map('mapCRUD').setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution: 'Map data &copy; OpenStreetMap contributors'
-}).addTo(map);
+var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data &copy; OpenStreetMap contributors'
+});
+
+var googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
+        maxZoom: 20,
+        subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
+});
+
+osmLayer.addTo(map);
+
+var baseLayers = {
+        'OpenStreetMap': osmLayer,
+        'Satélite (Google)': googleHybrid
+};
+
+L.control.layers(baseLayers, null, {position: 'topright'}).addTo(map);
+L.control.scale({position: 'bottomright', metric: true, imperial: false}).addTo(map);
 
 var drawnItems = new L.FeatureGroup();
 map.addLayer(drawnItems);
 
-googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
-    maxZoom: 20,
-    subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
-});
-googleHybrid.addTo(map);
+customizeDrawTexts();
 
 var drawControl = new L.Control.Draw({
-    edit: {
-        featureGroup: drawnItems
-    },
-    draw: {
-        polygon: {
-            allowIntersection: false,
-            showArea: true
+        edit: {
+                featureGroup: drawnItems,
+                remove: true
         },
-        polyline: false,
-        rectangle: {
-            showArea: true
-        },
-        circle: false,
-        marker: false
-    }
+        draw: {
+                polygon: {
+                        allowIntersection: false,
+                        showArea: true,
+                        shapeOptions: defaultShapeOptions()
+                },
+                rectangle: false,
+                polyline: false,
+                marker: false,
+                circlemarker: false,
+                circle: {
+                        showRadius: true,
+                        shapeOptions: defaultShapeOptions()
+                }
+        }
 });
 map.addControl(drawControl);
 
-// Variável para armazenar o polígono desenhado
-var drawnPolygon
-drawnPolygon = renderGeoJSON();
+var drawnPolygon = renderGeoJSON();
+
+if (drawnPolygon) {
+        focusOnDrawing();
+}
 
 map.on(L.Draw.Event.CREATED, function (event) {
-    var layer = event.layer;
-	// drawnItems.removeLayer()
+        var layer = event.layer;
 
-    // Verifica se um polígono já foi desenhado
-    if (drawnPolygon) {
-        drawnItems.removeLayer(drawnPolygon);
-    }
+        if (event.layerType === 'circle') {
+                layer = convertCircleToPolygon(layer) || layer;
+        }
 
-    // Adiciona o novo polígono e atualiza a variável
-    drawnItems.addLayer(layer);
-    drawnPolygon = layer;
-
-    updateInputs(layer);
+        applySingleLayer(layer);
+        focusOnDrawing();
 });
 
 map.on('draw:edited', function (e) {
-    var layers = e.layers;
-    layers.eachLayer(function (layer) {
-        drawnItems.addLayer(layer);
-        updateInputs(layer);
-    });
+        e.layers.eachLayer(function (layer) {
+                drawnPolygon = layer;
+                if (layer.setStyle) {
+                        layer.setStyle(defaultShapeOptions());
+                }
+                createAreaTooltip(layer);
+                updateInputs(layer);
+        });
+        focusOnDrawing();
 });
 
+map.on('draw:deleted', function () {
+        resetInputs();
+        drawnPolygon = null;
+        focusOnDrawing();
+});
+
+var fitButton = document.getElementById('fit-drawing');
+if (fitButton) {
+        fitButton.addEventListener('click', function () {
+                focusOnDrawing();
+        });
+}
+
+var clearButton = document.getElementById('clear-drawing');
+if (clearButton) {
+        clearButton.addEventListener('click', function () {
+                handleClearDrawing();
+        });
+}
+
+window.addEventListener('resize', function () {
+        map.invalidateSize();
+});
+
+map.whenReady(function () {
+        setTimeout(function () {
+                map.invalidateSize();
+                focusOnDrawing();
+        }, 150);
+});
 
 function renderGeoJSON() {
-	var geojsonInput = document.getElementById("geo_json").value;
-	if (geojsonInput) {
-		var geojsonObject = JSON.parse(geojsonInput);
-		var geojsonLayer = L.geoJSON(geojsonObject);
-		drawnItems.addLayer(geojsonLayer);
-		map.fitBounds(geojsonLayer.getBounds());
-		return geojsonLayer;
-	}
-	return null;
+        var geojsonInput = document.getElementById('geo_json');
+        if (!geojsonInput || !geojsonInput.value) {
+                return null;
+        }
+
+        try {
+                var geojsonObject = JSON.parse(geojsonInput.value);
+                var polygonLayers = L.geoJSON(geojsonObject).getLayers();
+                if (polygonLayers.length) {
+                        var layer = polygonLayers[0];
+                        return applySingleLayer(layer);
+                }
+        } catch (error) {
+                console.error('Erro ao carregar o GeoJSON do talhão', error);
+        }
+
+        return null;
 }
 
+function customizeDrawTexts() {
+        if (!L.drawLocal || !L.drawLocal.draw) {
+                return;
+        }
+
+        var buttons = L.drawLocal.draw.toolbar.buttons || {};
+        buttons.polygon = 'Desenhar polígono';
+        buttons.circle = 'Desenhar pivô (círculo)';
+        buttons.rectangle = 'Desenhar retângulo';
+        L.drawLocal.draw.toolbar.buttons = buttons;
+
+        if (L.drawLocal.draw.handlers && L.drawLocal.draw.handlers.circle && L.drawLocal.draw.handlers.circle.tooltip) {
+                L.drawLocal.draw.handlers.circle.tooltip.start = 'Clique e arraste para desenhar o pivô circular.';
+        }
+        if (L.drawLocal.draw.handlers && L.drawLocal.draw.handlers.polygon && L.drawLocal.draw.handlers.polygon.tooltip) {
+                L.drawLocal.draw.handlers.polygon.tooltip.start = 'Clique para adicionar vértices ao polígono.';
+        }
+}
+
+function defaultShapeOptions() {
+        return {
+                color: '#0b6fa4',
+                weight: 2,
+                fillColor: '#3ba1d7',
+                fillOpacity: 0.25
+        };
+}
+
+function applySingleLayer(layer) {
+        if (!layer) {
+                return null;
+        }
+
+        drawnItems.clearLayers();
+        if (layer.setStyle) {
+                layer.setStyle(defaultShapeOptions());
+        }
+        drawnItems.addLayer(layer);
+        drawnPolygon = layer;
+        createAreaTooltip(layer);
+        updateInputs(layer);
+        return layer;
+}
+
+function handleClearDrawing() {
+        drawnItems.clearLayers();
+        resetInputs();
+        drawnPolygon = null;
+        map.setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
+}
+
+function focusOnDrawing() {
+        if (drawnPolygon) {
+                map.fitBounds(drawnPolygon.getBounds(), {padding: [40, 40]});
+        } else {
+                map.setView(MAP_INITIAL_CENTER, MAP_INITIAL_ZOOM);
+        }
+}
+
+function convertCircleToPolygon(circleLayer) {
+        var center = circleLayer.getLatLng();
+        var polygonGeo = turf.circle([center.lng, center.lat], circleLayer.getRadius() / 1000, {
+                steps: CIRCLE_STEPS,
+                units: 'kilometers'
+        });
+
+        var polygonLayers = L.geoJSON(polygonGeo).getLayers();
+        if (polygonLayers.length) {
+                var polygonLayer = polygonLayers[0];
+                if (circleLayer.options && polygonLayer.setStyle) {
+                        polygonLayer.setStyle(circleLayer.options);
+                } else if (polygonLayer.setStyle) {
+                        polygonLayer.setStyle(defaultShapeOptions());
+                }
+                return polygonLayer;
+        }
+
+        return null;
+}
+
+function getPrimaryLatLngs(layer) {
+        if (!layer || typeof layer.getLatLngs !== 'function') {
+                return [];
+        }
+
+        return extractFirstRing(layer.getLatLngs());
+}
+
+function extractFirstRing(latLngs) {
+        if (!Array.isArray(latLngs)) {
+                return [];
+        }
+        if (!latLngs.length) {
+                return [];
+        }
+        if (Array.isArray(latLngs[0])) {
+                return extractFirstRing(latLngs[0]);
+        }
+        return latLngs;
+}
 
 function updateInputs(layer) {
-    var bounds = layer.getBounds();
-    var bbox = bounds.toBBoxString();
-    var geojson = layer.toGeoJSON();
-    var wkt = wellknown.stringify(geojson);
-    var encondedWKT = encodeURIComponent(wkt);
-    var input_geojson = document.getElementById("geo_json")
-    input_geojson.value = JSON.stringify(geojson);
-    var input_wkt = document.getElementById("wkt")
-    input_wkt.value = encondedWKT;
-    var input_bbox = document.getElementById("bbox")
-    input_bbox.value = bbox;
+        if (!layer) {
+                return;
+        }
 
-    createAreaTooltip(layer);
-    var area = L.GeometryUtil.geodesicArea(layer.getLatLngs()[0]); // Get polygon area
-    var areaHa = area / 10000; // Convert area to hectares
-    var input_area = document.getElementById("area")
-    input_area.value = areaHa;
-}
+        var bounds = layer.getBounds();
+        if (bounds && typeof bounds.isValid === 'function' && !bounds.isValid()) {
+                return;
+        }
 
+        var bbox = bounds.toBBoxString();
+        var geojson = layer.toGeoJSON();
+        var wkt = wellknown.stringify(geojson);
+        var encodedWKT = encodeURIComponent(wkt);
 
+        var inputGeoJson = document.getElementById('geo_json');
+        if (inputGeoJson) {
+                inputGeoJson.value = JSON.stringify(geojson);
+        }
 
-function fetchNDVIData(layer) {
-    var wkt = wellknown.stringify(layer.toGeoJSON());
-    var encodedWKT = encodeURIComponent(wkt);
-    var url = `https://services.sentinel-hub.com/ogc/wms/${SENTINELHUB_ID}?service=WMS&request=GetMap&layers=NDVI&styles=&format=application/json&transparent=true&RESX=10m&RESY=10m&srs=CRS:84&geometry=${encodedWKT}/`;
-    console.log(url);
+        var inputWkt = document.getElementById('wkt');
+        if (inputWkt) {
+                inputWkt.value = encodedWKT;
+        }
 
-    // Fetch NDVI data in GeoJSON
-    fetch(url)
-        .then(response => response.json())
-        .then(data => {
-            let counter = 0;
-            var geoJsonLayer = L.geoJSON(data, {
-                onEachFeature: function (feature, layer) {
-                    layer.setStyle({
-                        color: `#${feature.properties.COLOR_HEX}`,
-                        stroke: true,
-                        weight: 1,
-                        fill: true,
-                        fillOpacity: 1,
-                        fillColor: `#${feature.properties.COLOR_HEX}`
-                    });
-                    counter++;
+        var inputBbox = document.getElementById('bbox');
+        if (inputBbox) {
+                inputBbox.value = bbox;
+        }
+
+        var latLngs = getPrimaryLatLngs(layer);
+        if (latLngs.length && L.GeometryUtil && L.GeometryUtil.geodesicArea) {
+                var area = L.GeometryUtil.geodesicArea(latLngs);
+                var inputArea = document.getElementById('area');
+                if (inputArea) {
+                        inputArea.value = area / 10000;
                 }
-            }).addTo(map);
-            map.fitBounds(geoJsonLayer.getBounds());
-        })
-        .catch(error => console.error('Error fetching NDVI data:', error));
+        }
+
+        updateAreaTooltip(layer);
 }
 
+function resetInputs() {
+        ['geo_json', 'wkt', 'bbox', 'area'].forEach(function (fieldId) {
+                var input = document.getElementById(fieldId);
+                if (input) {
+                        input.value = '';
+                }
+        });
+}
 
 function createAreaTooltip(layer) {
-	if (layer.areaTooltip) {
-		updateAreaTooltip(layer); 
-		return;
-	}
+        if (!layer || typeof layer.getLatLngs !== 'function') {
+                return;
+        }
 
-	layer.areaTooltip = L.tooltip({
-		permanent: true,
-		direction: 'center',
-		className: 'area-tooltip'
-	});
+        if (layer.areaTooltip) {
+                updateAreaTooltip(layer);
+                return;
+        }
 
-	layer.on('remove', function(event) {
-		layer.areaTooltip.remove();
-	});
+        layer.areaTooltip = L.tooltip({
+                permanent: true,
+                direction: 'center',
+                className: 'area-tooltip'
+        });
 
-	layer.on('add', function(event) {
-		updateAreaTooltip(layer);
-		layer.areaTooltip.addTo(map);
-	});
+        layer.on('remove', function () {
+                if (layer.areaTooltip) {
+                        layer.areaTooltip.remove();
+                }
+        });
 
-	if (map.hasLayer(layer)) {
-		updateAreaTooltip(layer);
-		layer.areaTooltip.addTo(map);
-	}
+        layer.on('add', function () {
+                updateAreaTooltip(layer);
+                if (layer.areaTooltip) {
+                        layer.areaTooltip.addTo(map);
+                }
+        });
+
+        if (map.hasLayer(layer) && layer.areaTooltip) {
+                updateAreaTooltip(layer);
+                layer.areaTooltip.addTo(map);
+        }
 }
 
 function updateAreaTooltip(layer) {
-	var area = L.GeometryUtil.geodesicArea(layer.getLatLngs()[0]);
-	var readableArea = L.GeometryUtil.readableArea(area, true);
-	var latlng = layer.getCenter();
+        if (!layer || !layer.areaTooltip) {
+                return;
+        }
 
-	layer.areaTooltip
-		.setContent(readableArea)
-		.setLatLng(latlng);
+        var latLngs = getPrimaryLatLngs(layer);
+        if (!latLngs.length || !L.GeometryUtil || !L.GeometryUtil.geodesicArea) {
+                return;
+        }
+
+        var area = L.GeometryUtil.geodesicArea(latLngs);
+        var readableArea = L.GeometryUtil.readableArea(area, true);
+        var center = layer.getBounds().getCenter();
+
+        layer.areaTooltip
+                .setContent(readableArea)
+                .setLatLng(center);
 }
 
+function fetchNDVIData(layer) {
+        var wkt = wellknown.stringify(layer.toGeoJSON());
+        var encodedWKT = encodeURIComponent(wkt);
+        var url = `https://services.sentinel-hub.com/ogc/wms/${SENTINELHUB_ID}?service=WMS&request=GetMap&layers=NDVI&styles=&format=application/json&transparent=true&RESX=10m&RESY=10m&srs=CRS:84&geometry=${encodedWKT}/`;
 
+        fetch(url)
+                .then(response => response.json())
+                .then(data => {
+                        var geoJsonLayer = L.geoJSON(data, {
+                                onEachFeature: function (feature, layer) {
+                                        layer.setStyle({
+                                                color: `#${feature.properties.COLOR_HEX}`,
+                                                stroke: true,
+                                                weight: 1,
+                                                fill: true,
+                                                fillOpacity: 1,
+                                                fillColor: `#${feature.properties.COLOR_HEX}`
+                                        });
+                                }
+                        }).addTo(map);
+                        map.fitBounds(geoJsonLayer.getBounds());
+                })
+                .catch(error => console.error('Error fetching NDVI data:', error));
+}
 </script>

--- a/js/talhao_show.js.php
+++ b/js/talhao_show.js.php
@@ -8,18 +8,34 @@
 <script>
     var map = L.map('mapShow').setView([-17.047558, -46.824176], 13);
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+var satelliteLayer = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+    attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+    maxZoom: 20
+});
+
+var osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: 'Map data &copy; OpenStreetMap contributors'
-}).addTo(map);
+});
 
-var drawnItems = new L.FeatureGroup(); 
-map.addLayer(drawnItems);
-
-googleHybrid = L.tileLayer('http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
+var googleHybrid = L.tileLayer('https://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}', {
     maxZoom: 20,
     subdomains: ['mt0', 'mt1', 'mt2', 'mt3']
 });
-googleHybrid.addTo(map);
+
+satelliteLayer.addTo(map);
+
+var baseLayers = {
+    'Imagem de satélite (Esri)': satelliteLayer,
+    'Satélite (Google)': googleHybrid,
+    'Mapa de ruas (OSM)': osmLayer
+};
+
+L.control.layers(baseLayers, null, {position: 'topright'}).addTo(map);
+
+var drawnItems = new L.FeatureGroup();
+map.addLayer(drawnItems);
+
+L.control.scale({position: 'bottomright', metric: true, imperial: false}).addTo(map);
 
 
 var drawnPolygon

--- a/talhao_card.php
+++ b/talhao_card.php
@@ -262,12 +262,32 @@ if ($action == 'create') {
 		accessforbidden('NotEnoughPermissions', 0, 1);
 	}
 
-	print '<div class="container">';
+        print '<div class="talhao-layout">';
 
-	// debut div item 1 / map
-	print '<div class="item" id="mapCRUD"></div>';
-	
-	print '<div class="item">'; 
+        // debut div item 1 / map
+        print '<div class="item map-column">';
+        print '        <div class="map-panel">';
+        print '                <div class="map-panel__header">';
+        print '                        <h3>Desenho do talhão</h3>';
+        print '                        <p>Escolha uma das ferramentas para desenhar o perímetro. Para pivôs centrais utilize o círculo: o desenho será convertido automaticamente em um polígono compatível com o Sentinel Hub ao salvar.</p>';
+        print '                </div>';
+        print '                <div class="map-panel__toolbar">';
+        print '                        <button type="button" class="map-panel__btn" id="fit-drawing">Recentralizar desenho</button>';
+        print '                        <button type="button" class="map-panel__btn map-panel__btn--secondary" id="clear-drawing">Limpar desenho</button>';
+        print '                </div>';
+        print '                <div class="map-panel__map" id="mapCRUD"></div>';
+        print '                <div class="map-panel__tips">';
+        print '                        <strong>Dicas rápidas</strong>';
+        print '                        <ul>';
+        print '                                <li>Utilize o ícone de polígono para áreas irregulares.</li>';
+        print '                                <li>Para pivôs centrais, selecione o ícone de círculo: ele será convertido em polígono ao enviar.</li>';
+        print '                                <li>Use a lixeira do menu ou o botão limpar para começar novamente.</li>';
+        print '                        </ul>';
+        print '                </div>';
+        print '        </div>';
+        print '</div>';
+
+        print '<div class="item form-column">';
 
 	print load_fiche_titre($title, '', 'object_'.$object->picto);
 
@@ -309,9 +329,9 @@ if ($action == 'create') {
 	print '</form>';
 
 	// fin div item 2
-	print '</div>';
-	// fin div container
-	print '</div>';
+        print '</div>';
+        // fin div container
+        print '</div>';
 	
 	include_once './js/talhao_create.js.php';
 	// echo 'testers';
@@ -322,12 +342,32 @@ if ($action == 'create') {
 // Part to edit record
 if (($id || $ref) && $action == 'edit') {
 
-	print '<div class="container">';
+        print '<div class="talhao-layout">';
 
-	// debut div item 1 / map
-	print '<div class="item" id="mapCRUD"></div>';
-	
-	print '<div class="item">'; 
+        // debut div item 1 / map
+        print '<div class="item map-column">';
+        print '        <div class="map-panel">';
+        print '                <div class="map-panel__header">';
+        print '                        <h3>Desenho do talhão</h3>';
+        print '                        <p>Edite o perímetro utilizando as ferramentas de polígono ou círculo. Desenhos circulares são convertidos automaticamente para polígonos antes de salvar.</p>';
+        print '                </div>';
+        print '                <div class="map-panel__toolbar">';
+        print '                        <button type="button" class="map-panel__btn" id="fit-drawing">Recentralizar desenho</button>';
+        print '                        <button type="button" class="map-panel__btn map-panel__btn--secondary" id="clear-drawing">Limpar desenho</button>';
+        print '                </div>';
+        print '                <div class="map-panel__map" id="mapCRUD"></div>';
+        print '                <div class="map-panel__tips">';
+        print '                        <strong>Dicas rápidas</strong>';
+        print '                        <ul>';
+        print '                                <li>Atualize o contorno arrastando os vértices do polígono.</li>';
+        print '                                <li>Para pivôs, redesenhe com o círculo e o sistema gerará um polígono automaticamente.</li>';
+        print '                                <li>Use os botões acima para recentralizar ou limpar o desenho atual.</li>';
+        print '                        </ul>';
+        print '                </div>';
+        print '        </div>';
+        print '</div>';
+
+        print '<div class="item form-column">';
 
 	print load_fiche_titre($langs->trans("Talhao"), '', 'object_'.$object->picto);
 
@@ -688,14 +728,118 @@ $db->close();
 ?>
 
 <style>
-	
+.talhao-layout {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        align-items: flex-start;
+}
 
-    .container{
-        flex-wrap: nowrap;
-    }
+.talhao-layout .item {
+        flex: 1 1 420px;
+        min-width: 320px;
+}
 
-    .item{
-        max-width: 45%;
-    }
+.talhao-layout .map-column {
+        flex: 1 1 500px;
+}
 
+.talhao-layout .form-column {
+        flex: 1 1 460px;
+}
+
+.map-panel {
+        background: #fff;
+        border: 1px solid #d7d7d7;
+        border-radius: 10px;
+        padding: 1.25rem;
+        box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.map-panel__header h3 {
+        margin: 0 0 0.35rem;
+        font-size: 1.2rem;
+        color: #0b6fa4;
+}
+
+.map-panel__header p {
+        margin: 0;
+        color: #4b5563;
+        line-height: 1.5;
+        font-size: 0.95rem;
+}
+
+.map-panel__toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+}
+
+.map-panel__btn {
+        background: #0b6fa4;
+        border: none;
+        border-radius: 6px;
+        color: #fff;
+        cursor: pointer;
+        font-size: 0.9rem;
+        padding: 0.5rem 0.9rem;
+        transition: background 0.2s ease;
+}
+
+.map-panel__btn:hover,
+.map-panel__btn:focus {
+        background: #094f75;
+}
+
+.map-panel__btn--secondary {
+        background: #f3f4f6;
+        color: #1f2937;
+        border: 1px solid #d1d5db;
+}
+
+.map-panel__btn--secondary:hover,
+.map-panel__btn--secondary:focus {
+        background: #e5e7eb;
+}
+
+.map-panel__map {
+        height: 480px;
+        border-radius: 10px;
+        overflow: hidden;
+}
+
+.map-panel__tips {
+        font-size: 0.9rem;
+        color: #374151;
+        line-height: 1.45;
+}
+
+.map-panel__tips ul {
+        margin: 0.5rem 0 0;
+        padding-left: 1.2rem;
+}
+
+.map-panel__tips li + li {
+        margin-top: 0.35rem;
+}
+
+@media (max-width: 992px) {
+        .talhao-layout {
+                flex-direction: column;
+        }
+
+        .talhao-layout .item,
+        .talhao-layout .map-column,
+        .talhao-layout .form-column {
+                width: 100%;
+                min-width: 0;
+        }
+
+        .map-panel__map {
+                height: 360px;
+        }
+}
 </style>

--- a/talhao_card.php
+++ b/talhao_card.php
@@ -730,7 +730,7 @@ $db->close();
 <style>
 .talhao-layout {
         display: grid;
-        grid-template-columns: minmax(0, 1.45fr) minmax(0, 0.85fr);
+        grid-template-columns: minmax(0, 0.9fr) minmax(0, 0.85fr);
         gap: 1.5rem;
         align-items: flex-start;
 }
@@ -816,6 +816,7 @@ $db->close();
 .map-panel__map .leaflet-container {
         width: 100% !important;
         height: 100% !important;
+		display: flex;
 }
 
 .map-panel__tips {

--- a/talhao_card.php
+++ b/talhao_card.php
@@ -265,7 +265,7 @@ if ($action == 'create') {
         print '<div class="talhao-layout">';
 
         // debut div item 1 / map
-        print '<div class="item map-column">';
+print '<div class="item map-column">';
         print '        <div class="map-panel">';
         print '                <div class="map-panel__header">';
         print '                        <h3>Desenho do talhão</h3>';
@@ -275,7 +275,7 @@ if ($action == 'create') {
         print '                        <button type="button" class="map-panel__btn" id="fit-drawing">Recentralizar desenho</button>';
         print '                        <button type="button" class="map-panel__btn map-panel__btn--secondary" id="clear-drawing">Limpar desenho</button>';
         print '                </div>';
-        print '                <div class="map-panel__map" id="mapCRUD"></div>';
+print '                <div class="map-panel__map" id="mapCRUD"></div>';
         print '                <div class="map-panel__tips">';
         print '                        <strong>Dicas rápidas</strong>';
         print '                        <ul>';
@@ -729,23 +729,22 @@ $db->close();
 
 <style>
 .talhao-layout {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: minmax(0, 1.45fr) minmax(0, 0.85fr);
         gap: 1.5rem;
         align-items: flex-start;
 }
 
 .talhao-layout .item {
-        flex: 1 1 420px;
-        min-width: 320px;
+        min-width: 0;
 }
 
 .talhao-layout .map-column {
-        flex: 1 1 500px;
+        width: 100%;
 }
 
 .talhao-layout .form-column {
-        flex: 1 1 460px;
+        width: 100%;
 }
 
 .map-panel {
@@ -806,9 +805,17 @@ $db->close();
 }
 
 .map-panel__map {
-        height: 480px;
+        width: 100%;
+        height: 520px;
+        min-height: 520px;
         border-radius: 10px;
         overflow: hidden;
+        position: relative;
+}
+
+.map-panel__map .leaflet-container {
+        width: 100% !important;
+        height: 100% !important;
 }
 
 .map-panel__tips {
@@ -826,20 +833,20 @@ $db->close();
         margin-top: 0.35rem;
 }
 
+@media (max-width: 1280px) {
+        .talhao-layout {
+                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        }
+}
+
 @media (max-width: 992px) {
         .talhao-layout {
-                flex-direction: column;
-        }
-
-        .talhao-layout .item,
-        .talhao-layout .map-column,
-        .talhao-layout .form-column {
-                width: 100%;
-                min-width: 0;
+                grid-template-columns: minmax(0, 1fr);
         }
 
         .map-panel__map {
-                height: 360px;
+                height: 380px;
+                min-height: 380px;
         }
 }
 </style>

--- a/talhao_list.php
+++ b/talhao_list.php
@@ -568,8 +568,16 @@ $varpage = empty($contextpage) ? $_SERVER["PHP_SELF"] : $contextpage;
 $selectedfields = ($mode != 'kanban' ? $form->multiSelectArrayWithCheckbox('selectedfields', $arrayfields, $varpage, getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN', '')) : ''); // This also change content of $arrayfields
 $selectedfields .= (count($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
 
-print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
-print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwithfilterbefore" : "").'">'."\n";
+print '<div class="talhao-list-lead" role="note">';
+print '        <span class="talhao-list-lead__icon"><i class="fa fa-map-marker"></i></span>';
+print '        <div class="talhao-list-lead__content">';
+print '                <strong>Organize seus talhões com mais clareza.</strong>';
+print '                <p>Combine a busca geral com os filtros de cada coluna para localizar rapidamente qualquer área. Clique no código do talhão para abrir sua ficha completa.</p>';
+print '        </div>';
+print '</div>';
+
+print '<div class="div-table-responsive talhao-list-container">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
+print '<table class="tagtable nobottomiftotal liste'.($moreforfilter ? " listwithfilterbefore" : "").' talhao-list-table">'."\n";
 
 // Fields title search
 // --------------------------------------------------------------------
@@ -787,13 +795,16 @@ while ($i < $imaxinloop) {
 					print ' title="'.dol_escape_htmltag($object->$key).'"';
 				}
 				print '>';
-				if ($key == 'status') {
-					print $object->getLibStatut(5);
-				} elseif ($key == 'rowid') {
-					print $object->showOutputField($val, $key, $object->id, '');
-				} else {
-					print $object->showOutputField($val, $key, $object->$key, '');
-				}
+                                if ($key == 'status') {
+                                        print '<span class="talhao-status-chip">'.$object->getLibStatut(5).'</span>';
+                                } elseif ($key == 'rowid') {
+                                        print $object->showOutputField($val, $key, $object->id, '');
+                                } elseif ($key == 'ref') {
+                                        $refValue = $object->showOutputField($val, $key, $object->$key, '');
+                                        print '<strong class="talhao-list-ref">'.$refValue.'</strong>';
+                                } else {
+                                        print $object->showOutputField($val, $key, $object->$key, '');
+                                }
 				print '</td>';
 				if (!$i) {
 					$totalarray['nbfield']++;
@@ -896,8 +907,116 @@ if (in_array('builddoc', array_keys($arrayofmassactions)) && ($nbtotalofrecords 
 
 ?>
 
+<style>
+.talhao-list-lead {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.85rem;
+        background: #edf6ff;
+        border: 1px solid #b8dcff;
+        border-radius: 10px;
+        padding: 1rem 1.25rem;
+        margin: 1rem 0 1.2rem;
+        color: #0b3b66;
+}
+
+.talhao-list-lead__icon {
+        font-size: 1.5rem;
+        color: #0b6fa4;
+        line-height: 1;
+        margin-top: 0.15rem;
+}
+
+.talhao-list-lead__content p {
+        margin: 0.35rem 0 0;
+        font-size: 0.95rem;
+        line-height: 1.5;
+}
+
+.talhao-list-container {
+        background: #fff;
+        border-radius: 14px;
+        box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+        padding: 0;
+        overflow: hidden;
+}
+
+.talhao-list-table {
+        width: 100%;
+        border-collapse: separate;
+        border-spacing: 0;
+}
+
+.talhao-list-table tr.liste_titre {
+        background: linear-gradient(90deg, #0b6fa4 0%, #1098c2 100%);
+        color: #fff;
+}
+
+.talhao-list-table tr.liste_titre th {
+        color: inherit;
+        font-weight: 600;
+        padding: 0.75rem 1rem;
+        border-bottom: none;
+}
+
+.talhao-list-table tr.liste_titre_filter td {
+        background: #f8fafc;
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #dbe5f2;
+}
+
+.talhao-list-table tr.liste_titre_filter input.flat,
+.talhao-list-table tr.liste_titre_filter select.flat,
+.talhao-list-table tr.liste_titre_filter .maxwidth100,
+.talhao-list-table tr.liste_titre_filter .maxwidth250 {
+        width: 100%;
+        border-radius: 6px;
+        border: 1px solid #cbd5e1;
+        padding: 0.35rem 0.5rem;
+        font-size: 0.9rem;
+}
+
+.talhao-list-table tr.oddeven td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid #edf2f9;
+        transition: background 0.2s ease;
+}
+
+.talhao-list-table tr.oddeven:hover td {
+        background: #f1f7ff;
+}
+
+.talhao-list-ref {
+        color: #0b6fa4;
+        font-weight: 600;
+}
+
+.talhao-status-chip {
+        display: inline-flex;
+        align-items: center;
+}
+
+.talhao-status-chip .badge {
+        padding: 0.3rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.85rem;
+}
+
+@media (max-width: 992px) {
+        .talhao-list-lead {
+                flex-direction: column;
+        }
+
+        .talhao-list-table tr.liste_titre_filter td,
+        .talhao-list-table tr.liste_titre th,
+        .talhao-list-table tr.oddeven td {
+                padding: 0.65rem;
+        }
+}
+</style>
+
 <script>
-	let json_pol = <?php echo json_encode($json_pol); ?>
+        let json_pol = <?php echo json_encode($json_pol); ?>
 </script>
 
 <?php


### PR DESCRIPTION
## Summary
- refresh the talhão create/edit layout with an instructional map panel and responsive styling
- add Leaflet draw enhancements that convert circles into polygons and expose map utilities during creation
- mirror the new drawing behaviour in the edit script, keeping Sentinel Hub integration compatible

## Testing
- php -l talhao_card.php

------
https://chatgpt.com/codex/tasks/task_e_68e3ce76e268833092bce30bc930769e